### PR TITLE
fix function isValid()

### DIFF
--- a/src/module/method.js
+++ b/src/module/method.js
@@ -10,7 +10,7 @@ export function isValid(id){
     id17.split('').forEach(function(value,index){
         sum += factor[index]*value;
     });
-    let lastLetter = ["1", "0", "X", "9", "8", "7", "6", "5", "4", "3", "2"];
+    let lastLetter = ["1", "0", "x", "9", "8", "7", "6", "5", "4", "3", "2"];
     let mod = sum%lastLetter.length;
     return lastLetter[mod]==last;
 };


### PR DESCRIPTION
修复当身份证包含 X/x 时未正确处理的问题

## 问题描述：

当身份证号包含`X/x`时，`isValid` = `false`，是由于 `toLowerCase` 与 `X` 不匹配引起的:

https://github.com/mumuy/idcard/blob/f058b28cca0afa72f4fa905899476ec687524e7f/src/module/method.js#L5

https://github.com/mumuy/idcard/blob/f058b28cca0afa72f4fa905899476ec687524e7f/src/module/method.js#L13

